### PR TITLE
Update MuseScore from v2 to v3

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -387,7 +387,7 @@ class _EnvironmentCore:
             for name, value in [
                 ('lilypondPath', 'lilypond'),
                 ('musescoreDirectPNGPath',
-                    common.cleanpath(r'%PROGRAMFILES(x86)%\MuseScore 2\MuseScore.exe')),
+                    common.cleanpath(r'%PROGRAMFILES(x86)%\MuseScore 3\MuseScore.exe')),
                 ]:
                 self.__setitem__(name, value)  # use for key checking
         elif platform == 'nix':
@@ -397,13 +397,13 @@ class _EnvironmentCore:
             for name, value in [
                     ('lilypondPath', 
                         '/Applications/Lilypond.app/Contents/Resources/bin/lilypond'),
-                    ('musicxmlPath', '/Applications/MuseScore 2.app/Contents/MacOS/mscore'),
+                    ('musicxmlPath', '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
                     ('graphicsPath', '/Applications/Preview.app'),
                     ('vectorPath', '/Applications/Preview.app'),
                     ('pdfPath', '/Applications/Preview.app'),
                     ('midiPath', '/Applications/Utilities/QuickTime Player 7.app'),
                     ('musescoreDirectPNGPath',
-                        '/Applications/MuseScore 2.app/Contents/MacOS/mscore'),
+                        '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
                 ]:
                 self.__setitem__(name, value)  # use for key checking
 
@@ -1454,8 +1454,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />
@@ -1507,8 +1507,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />
@@ -1559,8 +1559,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="w" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 2.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />


### PR DESCRIPTION
The latest version of MuseScore is v3. Running the configuration script will set "musicxmlPath
 correctly, but leave "musescoreDirectPNGPath" set to a path for MuseScore 2. Maybe it's better to dynamically update the "musescoreDirectPNGPath" to the path of the version of MuseScore that the user installs.